### PR TITLE
Introduction of a gromacs plugin

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ Installation:
   ~~~~~~~~~~
 Go to your ~/.vim directory
 
-If "syntax" and "ftdetect" directories don't exist, copy them from github.
+If "syntax", "ftdetect" and "ftplugins" directories don't exist, copy them from github.
 If they are, copy only files inside. Otherwise, existing files will be replaced.
 
   VimBall Way (Vim >= 7.0)
@@ -21,3 +21,21 @@ Open it with vi and type:
   - :so %
   - :q!
 
+============
+Plugin usage
+============
+
+  Get started
+  ~~~~~~~~~~~
+
+To have the gromacs plugin loaded for gromacs files only you need to allow filetype plugins. To allow it have "filetype plugin on" in yout .vimrc.
+
+To have gromacs plugin always allowed, move gromacs.vim from ~/.vim/ftplugin to ~/.vim/plugin.
+
+  Shortcuts
+  ~~~~~~~~~
+
+]; -- Comment the selection
+]: -- Uncomment the selection
+], -- Jump to the next section
+]! -- Jump to the previous section

--- a/ftdetect/gromacs.vim
+++ b/ftdetect/gromacs.vim
@@ -1,14 +1,14 @@
 " Molecular Dynamics Parameter file (mdp)
-au BufNewFile,BufRead *.mdp    setf mdp
-au BufNewFile,BufRead *.MDP    setf mdp
+au BufNewFile,BufRead *.mdp    setf mdp.gromacs
+au BufNewFile,BufRead *.MDP    setf mdp.gromacs
 
 " Index file (ndx)
-au BufNewFile,BufRead *.ndx    setf ndx
-au BufNewFile,BufRead *.NDX    setf ndx
+au BufNewFile,BufRead *.ndx    setf ndx.gromacs
+au BufNewFile,BufRead *.NDX    setf ndx.gromacs
 
 "Topology file (top, itp)
-au BufNewFile,BufRead *.top    setf top
-au BufNewFile,BufRead *.top    setf top
+au BufNewFile,BufRead *.top    setf top.gromacs
+au BufNewFile,BufRead *.TOP    setf top.gromacs
 
-au BufNewFile,BufRead *.itp    setf top
-au BufNewFile,BufRead *.itp    setf top
+au BufNewFile,BufRead *.itp    setf top.gromacs
+au BufNewFile,BufRead *.ITP    setf top.gromacs

--- a/ftplugin/gromacs.vim
+++ b/ftplugin/gromacs.vim
@@ -1,0 +1,71 @@
+"                                                                           
+"    This program is free software: you can redistribute it and/or modify  
+"    it under the terms of the GNU General Public License as published by   
+"    the Free Software Foundation, either version 3 of the License, or      
+"    (at your option) any later version.                                    
+"                                                                           
+"    This program is distributed in the hope that it will be useful,        
+"    but WITHOUT ANY WARRANTY; without even the implied warranty of         
+"    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          
+"    GNU General Public License for more details.                           
+"                                                                           
+"    A copy of the GNU General Public License is available at
+"    <http://www.gnu.org/licenses/>.
+
+
+" " Maintainer:         Jonathan Barnoud <jonathan@barnoud.net>
+" " Last Change:        23 Feb 2012
+
+" Shortcuts:
+"   ];      -- Comment the selected block
+"   ]:      -- Uncomment the selected block
+"   ],      -- Jump to the previous section
+"   ]!      -- Jump to the next section
+
+
+if exists("b:loaded_gmx_plugin")
+  finish
+endif
+let b:loaded_gmx_plugin = 1
+
+map  ];   :call GromacsCommentSelection()<CR>
+vmap ];   :call GromacsCommentSelection()<CR>
+map  ]:   :call GromacsUncommentSelection()<CR>
+vmap ]:   :call GromacsUncommentSelection()<CR>
+map  ],   :call GromacsMoveSection(1)<CR>
+map  ]!   :call GromacsMoveSection(-1)<CR>
+
+" Comment out selected lines
+" Add the comment character as first column
+function GromacsCommentSelection() range
+    let commentString = ";"
+    let cl = a:firstline
+    while (cl <= a:lastline)
+        let ul = substitute(getline(cl), "^\\(.*\\)$", commentString."\\1", "")
+        call setline(cl, ul)
+        let cl = cl + 1
+    endwhile
+endfunction
+
+" Uncomment  selected lines
+" Remove the first comment character
+function GromacsUncommentSelection() range
+    let commentString = ";"
+    let cl = a:firstline
+    while (cl <= a:lastline)
+        let ul = substitute(getline(cl),
+            \"\\([ \\t]*\\\)".commentString."\\(.*\\)$", "\\1\\2", "")
+        call setline(cl, ul)
+        let cl = cl + 1
+    endwhile
+endfunction
+
+" Move to the next (1) or previous (-1) section
+function GromacsMoveSection(direction)
+    let regexp = "\\[.*\\]"
+    let flag = "W"
+    if (a:direction == -1)
+        let flag = flag."b"
+    endif
+    let res = search(regexp, flag)
+endfunction


### PR DESCRIPTION
To have the gromacs plugin loaded for gromacs files only you need to allow filetype plugins. To allow it have "filetype plugin on" in yout .vimrc.

To have gromacs plugin always allowed, move gromacs.vim from ~/.vim/ftplugin to ~/.vim/plugin.

  Shortcuts

```

]; -- Comment the selection
]: -- Uncomment the selection
], -- Jump to the next section
]! -- Jump to the previous section
```
