### PR TITLE
Add number of atoms fix for gro files 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,18 +54,35 @@ Get Started
 
 Syntax highlighting should be automatic.
 
+Macros
+~~~~~~
+
 To use macros, you need to allow filetype plugins : "filetype plugin on" in
 your *.vimrc*.
 
 (If you want to have gromacs macros always allowed, move gromacs.vim from
 *~/.vim/ftplugin* to *~/.vim/plugin*)
 
+Completion
+~~~~~~~~~~
+
 To activate contextual completion in mdp files, add the following line in your
 *.vimrc*:
 
+::
     autocmd FileType mdp.gromacs set omnifunc=mdpcomplete#Complete
 
 Then completion is triggered in insert mode by <C-x><C-o>.
+
+Fix number of atoms when saving gro file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To automatically fix the number of atoms in gro files at saving time add the following line to your *.vimrc*:
+
+::
+    autocmd BufWritePre *.gro call Update_number_of_atoms()
+
+You can also update the number of atoms by using the "Unatoms" command.
 
 Tricks
 -------
@@ -78,6 +95,7 @@ type. It can be changed however. With the following instruction in your
 *.vimrc*, <C-n> will trigger the completion. The change will be active only for
 MDP files.
 
+::
     autocmd FileType mdp.gromacs imap <C-n> <C-x><C-o>
 
 Suggest values when you type =
@@ -86,6 +104,7 @@ Suggest values when you type =
 To have the possible values suggested when you write the = in a MDP file, just
 add the following line in your *vimrc*:
 
+::
     autocmd FileType mdp.gromacs imap <silent> <buffer> = = <C-X><C-O>
 
 Complete as you type
@@ -99,7 +118,6 @@ you have this plugin installed, add the following instructions to your
 *.vimrc*:
 
 ::
-
     function! Meet(text)
         return len(a:text)
     endfunction

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ To activate contextual completion in mdp files, add the following line in your
 *.vimrc*:
 
 ::
+
     autocmd FileType mdp.gromacs set omnifunc=mdpcomplete#Complete
 
 Then completion is triggered in insert mode by <C-x><C-o>.
@@ -80,6 +81,7 @@ Fix number of atoms when saving gro file
 To automatically fix the number of atoms in gro files at saving time add the following line to your *.vimrc*:
 
 ::
+
     autocmd BufWritePre *.gro call Update_number_of_atoms()
 
 You can also update the number of atoms by using the "Unatoms" command.
@@ -96,6 +98,7 @@ type. It can be changed however. With the following instruction in your
 MDP files.
 
 ::
+
     autocmd FileType mdp.gromacs imap <C-n> <C-x><C-o>
 
 Suggest values when you type =
@@ -105,6 +108,7 @@ To have the possible values suggested when you write the = in a MDP file, just
 add the following line in your *vimrc*:
 
 ::
+
     autocmd FileType mdp.gromacs imap <silent> <buffer> = = <C-X><C-O>
 
 Complete as you type
@@ -118,6 +122,7 @@ you have this plugin installed, add the following instructions to your
 *.vimrc*:
 
 ::
+
     function! Meet(text)
         return len(a:text)
     endfunction

--- a/ftplugin/gro.vim
+++ b/ftplugin/gro.vim
@@ -1,0 +1,26 @@
+if exists("b:loaded_gro_plugin")
+  finish
+endif
+let b:loaded_gro_plugin = 1
+
+function Number_of_atoms()
+    let line_idx = line('$')
+    while len(getline(line_idx)) == 0
+        let line_idx -= 1
+    endwhile
+    let natoms = line_idx - 3
+    return natoms
+endfunction
+
+function Declared_number_of_atoms()
+    return substitute(getline(2), ' ', '', 'g')
+endfunction
+
+function Update_number_of_atoms()
+    echo "hey ho!"
+    if Declared_number_of_atoms() - Number_of_atoms() != 0
+        call setline(2, Number_of_atoms())
+    endif
+endfunction
+
+command Unatoms call Update_number_of_atoms()


### PR DESCRIPTION
To fix the number of atoms run the "Unatoms" command.
To do the fix automatically at saving time add to your .vimrc:

```
autocmd BufWritePre *.gro call Update_number_of_atoms()
```
