### PR TITLE
Make functions and command redeclarable

### DIFF
--- a/ftplugin/gro.vim
+++ b/ftplugin/gro.vim
@@ -3,7 +3,7 @@ if exists("b:loaded_gro_plugin")
 endif
 let b:loaded_gro_plugin = 1
 
-function Number_of_atoms()
+function! Number_of_atoms()
     let line_idx = line('$')
     while len(getline(line_idx)) == 0
         let line_idx -= 1
@@ -12,15 +12,39 @@ function Number_of_atoms()
     return natoms
 endfunction
 
-function Declared_number_of_atoms()
+function! Declared_number_of_atoms()
     return substitute(getline(2), ' ', '', 'g')
 endfunction
 
-function Update_number_of_atoms()
+function! Update_number_of_atoms()
     if Declared_number_of_atoms() - Number_of_atoms() != 0
         call setline(2, Number_of_atoms())
         echo "Number of atoms updated!"
     endif
+endfunction
+
+function! Translate_one(line_num, dx, dy, dz)
+    let coord_index = [[20, 27], [28, 35], [36, 43]]
+    let coordinates = [0, 0, 0]
+    let dcoordinates = [a:dx, a:dy, a:dz]
+    let line = getline(a:line_num)
+    for i in [0, 1, 2]
+        let coordinates[i] = str2float(substitute(
+            \ line[coord_index[i][0]:coord_index[i][1]], ' ', '', 'g'))
+        let coordinates[i] += dcoordinates[i]
+        let line = substitute(line,
+            \ '^\(.\{'.(coord_index[i][0]+1).'\}\)\(.\{7\}\)\(.*\)$',
+            \ '\1'.printf('%7.3f', coordinates[i]).'\3', 'g')
+    endfor
+    call setline(a:line_num, line)
+endfunction
+
+function! Translate(dx, dy, dz) range
+    let i = a:firstline
+    while i <= a:lastline
+        call Translate_one(i, a:dx, a:dy, a:dz)
+        let i += 1
+    endwhile
 endfunction
 
 command Unatoms call Update_number_of_atoms()

--- a/ftplugin/gro.vim
+++ b/ftplugin/gro.vim
@@ -47,4 +47,4 @@ function! Translate(dx, dy, dz) range
     endwhile
 endfunction
 
-command Unatoms call Update_number_of_atoms()
+command! Unatoms call Update_number_of_atoms()


### PR DESCRIPTION
VIM used to complain when several buffers or tabs were open in the same time because the functions of the gro plugin already existed. This commit pull request fic this.

Also it add the function for atom translation. To use it, select some atoms in a gro file and type:

```
:call Translate(1.2, 2.3, 4.5)
```

where the arguments being the translation vector.
