### PR TITLE
Update the installation section of the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,21 +15,6 @@ The plugin also provides contextual autocompletion in mdp files.
 Installation
 ------------
 
-+ **Manual Way**
-
-Go to your ~/.vim directory.
-
-If *syntax*, *ftdetect* and *ftplugin* directories don't exist, copy them from
-github.  If they are, copy only files inside. Otherwise, existing files will be
-replaced.
-
-+ **Pathogen Way**
-
-Pathogen is a vim module which allows to load modules from there own directory.
-
-Install pathogen (https://github.com/tpope/vim-pathogen) and then clone this
-repository in ~/.vim/bundle. It works.
-
 + **VimBall Way (Vim >= 7.0)**
 
 Get the vimball *gromacs.vba*.
@@ -40,7 +25,20 @@ Open it with vi and type:
   :so %
   :q!
 
++ **Pathogen Way**
 
+Pathogen is a vim module which allows to load modules from there own directory.
+
+Install pathogen (https://github.com/tpope/vim-pathogen) and then clone this
+repository in ~/.vim/bundle. It works.
+
++ **Manual Way**
+
+Go to your ~/.vim directory.
+
+If *syntax*, *autoload*, *ftdetect*, and *ftplugin* directories don't exist,
+copy them from github.  If they are, copy only the files inside. Otherwise,
+existing files will be replaced.
 
 + **OS Supported**
 


### PR DESCRIPTION
The vimball method is the easiest way to install the module for people
that are not use to install vim plugins; it should appear first, before
the manual way which is the more painful and the more error prone
method.

The pathogen way is probably the cleanest way but it requires more
effort for users that are not already using it.

The commit change the order of the installation methods according to the
remarks above. It put first the vimball method, then the pathogen one,
and it put the manual way at the end. About the manual way, the commit
also add the "autoload" directory that needs to be copied and that was
not mentioned before.
